### PR TITLE
Fix "import" to fit Checkstyle

### DIFF
--- a/client/src/main/java/org/infinispan/crucial/CAtomicBoolean.java
+++ b/client/src/main/java/org/infinispan/crucial/CAtomicBoolean.java
@@ -1,6 +1,9 @@
 package org.infinispan.crucial;
 
-import java.io.*;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * @author Daniel

--- a/client/src/main/java/org/infinispan/crucial/CAtomicByteArray.java
+++ b/client/src/main/java/org/infinispan/crucial/CAtomicByteArray.java
@@ -1,6 +1,9 @@
 package org.infinispan.crucial;
 
-import java.io.*;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * @author Daniel

--- a/client/src/main/java/org/infinispan/crucial/CAtomicInt.java
+++ b/client/src/main/java/org/infinispan/crucial/CAtomicInt.java
@@ -1,7 +1,10 @@
 package org.infinispan.crucial;
 
 
-import java.io.*;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * @author Daniel

--- a/client/src/main/java/org/infinispan/crucial/CAtomicLong.java
+++ b/client/src/main/java/org/infinispan/crucial/CAtomicLong.java
@@ -1,7 +1,10 @@
 package org.infinispan.crucial;
 
 
-import java.io.*;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * @author Daniel


### PR DESCRIPTION
When I executed `mvn install`, I found an error about Checkstyle.

```
Caused by: org.apache.maven.plugin.checkstyle.exec.CheckstyleExecutorException: There are 4 errors reported by Checkstyle 6.11.2 with checkstyle.xml ruleset.
```

To fix this error, this patch modify several import statements.